### PR TITLE
開発環境: flowをいたので、react/prop-typeの無視を解除

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,12 @@ module.exports = {
     'plugin:flowtype/recommended',
   ],
   plugins: ['flowtype'],
+  settings: {
+    react: {
+      version: '16.1',
+      flowVersion: '0.70',
+    },
+  },
   rules: {
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
   },

--- a/src/components/SnsLinkButton/BaseButton.js
+++ b/src/components/SnsLinkButton/BaseButton.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 // @flow
 import React from 'react';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';

--- a/src/components/SnsLinkButton/GithubLinkButton.js
+++ b/src/components/SnsLinkButton/GithubLinkButton.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 // @flow
 import React from 'react';
 import BaseButton from './BaseButton';

--- a/src/components/SnsLinkButton/TwitterLinkButton.js
+++ b/src/components/SnsLinkButton/TwitterLinkButton.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 // @flow
 import React from 'react';
 import BaseButton from './BaseButton';


### PR DESCRIPTION
Flowの型定義をかくことで prop-type を指定したことにできるようになったので、eslintの除外ルールをはずしました。