### PR TITLE
Setup storybook notes

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,2 +1,3 @@
 import '@storybook/addon-actions/register';
 import '@storybook/addon-links/register';
+import '@storybook/addon-notes/register';

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@storybook/addon-actions": "^3.4.3",
     "@storybook/addon-links": "^3.4.3",
+    "@storybook/addon-notes": "^3.4.3",
     "@storybook/addon-storyshots": "^3.4.3",
     "@storybook/addons": "^3.4.3",
     "@storybook/react": "^3.4.3",

--- a/src/stories/__snapshots__/index.test.js.snap
+++ b/src/stories/__snapshots__/index.test.js.snap
@@ -1,39 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots SNSLinkButton FacebookLinkButton 1`] = `
-<div>
-  <div
-    style={
-      Object {
-        "backgroundColor": "#666",
-        "padding": "2em",
-      }
+<div
+  style={
+    Object {
+      "backgroundColor": "#666",
+      "padding": "2em",
     }
+  }
+>
+  <a
+    className={undefined}
+    href="https://www.facebook.com/makoto.henmi"
   >
-    <a
-      className={undefined}
-      href="https://www.facebook.com/makoto.henmi"
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-facebook-f fa-w-9 "
+      data-icon="facebook-f"
+      data-prefix="fab"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 264 512"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <svg
-        aria-hidden="true"
-        className="svg-inline--fa fa-facebook-f fa-w-9 "
-        data-icon="facebook-f"
-        data-prefix="fab"
-        role="img"
+      <path
+        d="M76.7 512V283H0v-91h76.7v-71.7C76.7 42.4 124.3 0 193.8 0c33.3 0 61.9 2.5 70.2 3.6V85h-48.2c-37.8 0-45.1 18-45.1 44.3V192H256l-11.7 91h-73.6v229"
+        fill="currentColor"
         style={Object {}}
-        viewBox="0 0 264 512"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M76.7 512V283H0v-91h76.7v-71.7C76.7 42.4 124.3 0 193.8 0c33.3 0 61.9 2.5 70.2 3.6V85h-48.2c-37.8 0-45.1 18-45.1 44.3V192H256l-11.7 91h-73.6v229"
-          fill="currentColor"
-          style={Object {}}
-        />
-      </svg>
-    </a>
-  </div>
-  <p>
-    クリックで指定ユーザのFacebookプロフィールへ遷移します。
-  </p>
+      />
+    </svg>
+  </a>
 </div>
 `;

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { withNotes } from '@storybook/addon-notes';
 import fontawesome from '@fortawesome/fontawesome';
 import brands from '@fortawesome/fontawesome-free-brands';
 
@@ -8,11 +9,11 @@ import FacebookLinkButton from '../components/SnsLinkButton/FacebookLinkButton';
 
 fontawesome.library.add(brands);
 
-storiesOf('SNSLinkButton', module).add('FacebookLinkButton', () => (
-  <div>
+storiesOf('SNSLinkButton', module).add(
+  'FacebookLinkButton',
+  withNotes('クリックで指定ユーザのFacebookプロフィールへ遷移します。')(() => (
     <div style={{ backgroundColor: '#666', padding: '2em' }}>
       <FacebookLinkButton facebookId="makoto.henmi" />
     </div>
-    <p>クリックで指定ユーザのFacebookプロフィールへ遷移します。</p>
-  </div>
-));
+  )),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,6 +130,15 @@
     global "^4.3.2"
     prop-types "^15.6.1"
 
+"@storybook/addon-notes@^3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-notes/-/addon-notes-3.4.3.tgz#6b2ccbfe6888c5686f8bc27ca0a69029376f7516"
+  dependencies:
+    babel-runtime "^6.26.0"
+    marked "^0.3.17"
+    prop-types "^15.6.1"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-storyshots@^3.4.3":
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/@storybook/addon-storyshots/-/addon-storyshots-3.4.3.tgz#23f2be8e6d8d281c6a65868d00abf9a0cac3babf"
@@ -5697,7 +5706,7 @@ markdown-loader@^2.0.2:
     loader-utils "^1.1.0"
     marked "^0.3.9"
 
-marked@^0.3.9:
+marked@^0.3.17, marked@^0.3.9:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
 


### PR DESCRIPTION
Storybook の notes addonアドオンを設定し、利用してみました。

参考 https://github.com/storybooks/storybook/tree/v3.4.3/addons/notes
でも、4系でインタフェースが変わるみたい。4系のほうが好きだが…alphaなのでやめとこう。
https://github.com/storybooks/storybook/tree/v4.0.0-alpha.4/addons/notes

# 蛇足
公開されてるstorybookみてみたらいろんなことができそうだった。 

https://wix.github.io/wix-style-react/?selectedKind=1.%20Foundation&selectedStory=1.2%20Text&full=0&addons=0&stories=1&panelRight=0